### PR TITLE
Fix issue when req.filename is undefined

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,7 +42,7 @@ cds.once("served", async function registerPluginHandlers() {
             srv.before('NEW', target.drafts, req => {
               req.data.url = cds.utils.uuid();
               req.data.ID = cds.utils.uuid();
-              let ext = extname(req.data.filename).toLowerCase().slice(1);
+              let ext = extname(req.data.filename || '').toLowerCase().slice(1);
               req.data.mimeType = Ext2MimeTyes[ext] || "application/octet-stream";
             });
           }


### PR DESCRIPTION
In our case, this (for whatever reason) gets triggered if we create a parent entity which links via composition to children and those children link to attachments. Then, when creating the parent for whichever reason this handler is triggered and fails.